### PR TITLE
allow for alternative image host URL, only output public toots

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 ## How to
 
 1. Drop the (unzipped) mastodon export (generated from `your_instance.domain/settings/export`) into the root with the folder name `archive`
-2. Run `python3 mastodon-archive.py`
+2. Run `python3 mastodon-archive.py your_image_host_url_prefix` (e.g. `python3 mastodon-archive.py https://assets.chaos.social` for a chaos.social export)
 3. Your output will be generated in `docs/index.html`

--- a/mastodon-archive.py
+++ b/mastodon-archive.py
@@ -3,10 +3,9 @@ from os import path
 from datetime import datetime
 import sys
 
-IMAGE_HOST = 'https://media.ricard.social'
+imageHost = 'https://media.ricard.social'
 if len(sys.argv) > 1:
-    IMAGE_HOST = sys.argv[1]
-print(IMAGE_HOST)
+    imageHost = sys.argv[1]
 
 with open("archive/outbox.json", "r") as outbox_file:
     outbox = json.loads(outbox_file.read())
@@ -51,7 +50,7 @@ for status in statuses:
 
         images = ""
         for imageURL in attachments:
-          images += "<a href='{0}{1}'><img loading='lazy' class='item__image' src='{0}{1}'></a>".format(IMAGE_HOST, imageURL)
+          images += "<a href='{0}{1}'><img loading='lazy' class='item__image' src='{0}{1}'></a>".format(imageHost, imageURL)
 
         summary = status.get("summary")
         if summary:

--- a/mastodon-archive.py
+++ b/mastodon-archive.py
@@ -1,6 +1,12 @@
 import json
 from os import path
 from datetime import datetime
+import sys
+
+IMAGE_HOST = 'https://media.ricard.social'
+if len(sys.argv) > 1:
+    IMAGE_HOST = sys.argv[1]
+print(IMAGE_HOST)
 
 with open("archive/outbox.json", "r") as outbox_file:
     outbox = json.loads(outbox_file.read())
@@ -20,6 +26,9 @@ pathOffset = 1
 for status in statuses:
     # need to ignore objects that arent status dicts
     if type(status) == type({}):
+        if not "https://www.w3.org/ns/activitystreams#Public" in (status.get("to", []) + status.get("cc", [])):
+            # Toot is not public, let's not output it.
+            continue
         # get the date from the statuses (eg. 2024-01-15T16:52:47Z)
         date = status.get("published")
         # convert the date string to a datetime object
@@ -42,7 +51,7 @@ for status in statuses:
 
         images = ""
         for imageURL in attachments:
-          images += "<a href='https://media.ricard.social{0}'><img loading='lazy' class='item__image' src='https://media.ricard.social{0}'></a>".format(imageURL)
+          images += "<a href='{0}{1}'><img loading='lazy' class='item__image' src='{0}{1}'></a>".format(IMAGE_HOST, imageURL)
 
         summary = status.get("summary")
         if summary:


### PR DESCRIPTION
Added some code to pass in an image host (media/asset) URL as a parameter, limit outputting to only public toots.